### PR TITLE
Fix php8 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
 		"source":"https://github.com/madeyourday/contao-rocksolid-theme-assistant"
 	},
 	"require":{
-		"php":">=5.5",
-		"contao/core-bundle":"^4.3"
+		"php":">=7.2",
+		"contao/core-bundle":"^4.9"
 	},
 	"require-dev": {
 		"contao/manager-plugin": "^2.0"

--- a/src/ThemeAssistant.php
+++ b/src/ThemeAssistant.php
@@ -677,9 +677,14 @@ class ThemeAssistant extends \Backend
 
 		extract($data);
 		ob_start();
-		eval('?>' . $_phpCode . '<?php ');
 
-		return ob_get_clean() ?: '';
+		try {
+			eval('?>' . $_phpCode . '<?php ');
+			return ob_get_contents() ?: '';
+		}
+		finally {
+			ob_end_clean();
+		}
 	}
 
 	protected function renderCssTemplate($template, $data)

--- a/src/ThemeAssistant.php
+++ b/src/ThemeAssistant.php
@@ -783,7 +783,7 @@ class ThemeAssistant extends \Backend
 
 			$color1 = substr(trim($params[0]), 1);
 			$color2 = substr(trim($params[1]), 1);
-			$weight = isset($params[2]) ? $params[2]/100 : 0.5;
+			$weight = isset($params[2]) ? floatval($params[2]) / 100 : 0.5;
 
 			return strtolower('#'
 				.sprintf("%02X",(int)((hexdec(substr($color1, 0, 2))*$weight) + (hexdec(substr($color2, 0, 2))*(1-$weight)))) // red
@@ -795,7 +795,7 @@ class ThemeAssistant extends \Backend
 		if ($function === 'lighten' || $function === 'darken') {
 
 			$color = substr($params[0], 1);
-			$weight = $params[1]/100;
+			$weight = floatval($params[1]) / 100;
 			$color = static::colorRgbToHsl(array(hexdec(substr($color, 0, 2)), hexdec(substr($color, 2, 2)), hexdec(substr($color, 4, 2))));
 			$color[2] += $weight * ($function === 'lighten' ? 1 : -1);
 			$color[2] = max(0, min(1, $color[2]));
@@ -807,7 +807,7 @@ class ThemeAssistant extends \Backend
 		if ($function === 'saturate' || $function === 'desaturate') {
 
 			$color = substr($params[0], 1);
-			$weight = $params[1]/100;
+			$weight = floatval($params[1]) / 100;
 			$color = static::colorRgbToHsl(array(hexdec(substr($color, 0, 2)), hexdec(substr($color, 2, 2)), hexdec(substr($color, 4, 2))));
 			$color[1] += $weight * ($function === 'saturate' ? 1 : -1);
 			$color[1] = max(0, min(1, $color[1]));
@@ -819,7 +819,7 @@ class ThemeAssistant extends \Backend
 		if ($function === 'adjust-hue') {
 
 			$color = substr($params[0], 1);
-			$degrees = $params[1] / 360;
+			$degrees = floatval($params[1]) / 360;
 			$color = static::colorRgbToHsl(array(hexdec(substr($color, 0, 2)), hexdec(substr($color, 2, 2)), hexdec(substr($color, 4, 2))));
 			$color[0] += $degrees;
 			while ($color[0] < 0) {

--- a/src/ThemeAssistantDataContainer.php
+++ b/src/ThemeAssistantDataContainer.php
@@ -169,7 +169,7 @@ class ThemeAssistantDataContainer extends \DataContainer implements \listable, \
 
 		$return .= '<div id="tl_buttons">' . $this->generateGlobalButtons() . '</div>' . \Message::generate(true);
 		$return .= '<div class="tl_listing_container list_view">';
-		$return .= '<table class="tl_listing' . ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ? ' showColumns' : '') . '">';
+		$return .= '<table class="tl_listing' . (!empty($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns']) ? ' showColumns' : '') . '">';
 
 		foreach ($themeList as $key => $theme) {
 
@@ -264,7 +264,7 @@ class ThemeAssistantDataContainer extends \DataContainer implements \listable, \
 						$legends[$k] = substr($vv, 1, -1);
 						unset($boxes[$k][$kk]);
 					}
-					elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv]['exclude'] || !is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv])) {
+					elseif (!empty($GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv]['exclude']) || !\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv])) {
 						unset($boxes[$k][$kk]);
 					}
 
@@ -328,18 +328,18 @@ class ThemeAssistantDataContainer extends \DataContainer implements \listable, \
 					$this->varValue = '';
 
 					// Autofocus the first field
-					if ($blnIsFirst && $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['inputType'] == 'text') {
+					if ($blnIsFirst && isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['inputType']) && $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['inputType'] == 'text') {
 						$GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['autofocus'] = 'autofocus';
 						$blnIsFirst = false;
 					}
 
 					// Convert CSV fields (see #2890)
-					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['multiple'] && isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['csv'])) {
+                    if (!empty($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['multiple']) && isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['csv'])) {
 						$this->varValue = \StringUtil::trimsplit($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['csv'], $this->varValue);
 					}
 
 					// Call load_callback
-					if (is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'])) {
+					if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback']) && \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'])) {
 						foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] as $callback) {
 							if (is_array($callback)) {
 								$this->import($callback[0]);
@@ -379,8 +379,7 @@ class ThemeAssistantDataContainer extends \DataContainer implements \listable, \
 		         . '</script>';
 
 		// Begin the form (-> DO NOT CHANGE THIS ORDER -> this way the onsubmit attribute of the form can be changed by a field)
-		$return = $version
-		        . '<div id="tl_buttons">'
+		$return = '<div id="tl_buttons">'
 		        . '<a href="'.$this->getReferer(true).'" class="header_back" title="'.\StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']).'" accesskey="b" onclick="Backend.getScrollOffset()">'.$GLOBALS['TL_LANG']['MSC']['backBT'].'</a>'
 		        . '</div>'
 		        . '<h2 class="sub_headline">'.sprintf($GLOBALS['TL_LANG']['MSC']['editRecord'], ($this->intId ? $this->intId : '')).'</h2>'

--- a/src/ThemeAssistantDataContainer.php
+++ b/src/ThemeAssistantDataContainer.php
@@ -42,7 +42,7 @@ class ThemeAssistantDataContainer extends \DataContainer implements \listable, \
 		$this->arrModule = $arrModule;
 
 		// Call onload_callback (e.g. to check permissions)
-		if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback'])) {
+		if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback'] ?? null)) {
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback'] as $callback) {
 				if (is_array($callback)) {
 					$this->import($callback[0]);
@@ -328,18 +328,18 @@ class ThemeAssistantDataContainer extends \DataContainer implements \listable, \
 					$this->varValue = '';
 
 					// Autofocus the first field
-					if ($blnIsFirst && isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['inputType']) && $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['inputType'] == 'text') {
+					if ($blnIsFirst && ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['inputType'] ?? null) == 'text') {
 						$GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['autofocus'] = 'autofocus';
 						$blnIsFirst = false;
 					}
 
 					// Convert CSV fields (see #2890)
-                    if (!empty($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['multiple']) && isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['csv'])) {
+					if (!empty($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['multiple']) && isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['csv'])) {
 						$this->varValue = \StringUtil::trimsplit($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['csv'], $this->varValue);
 					}
 
 					// Call load_callback
-					if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback']) && \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'])) {
+					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] ?? null)) {
 						foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] as $callback) {
 							if (is_array($callback)) {
 								$this->import($callback[0]);
@@ -396,7 +396,7 @@ class ThemeAssistantDataContainer extends \DataContainer implements \listable, \
 		if (\Input::post('FORM_SUBMIT') == $this->strTable && !$this->noReload) {
 
 			// Trigger the onsubmit_callback
-			if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'])) {
+			if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] ?? null)) {
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] as $callback) {
 					$this->import($callback[0]);
 					$this->{$callback[0]}->{$callback[1]}($this);


### PR DESCRIPTION
- undefined key warnings
- undefined variable
- non numeric values with percent suffix

Attention there are even some changes necessary in the `main.css.base` of some of your themes - especially oneo:
```scss
/*: if ($f('lightness', $v['main-background']) < 50): */
...
/*: $unit = trim($v['max-width'], '0123456789.- ') */
max-width: /*:= (str_replace($unit, '', $v['max-width']) / 32 * 30) . $unit */;
...
/*: $unit = trim($v['secondary-navigation-margin'], '0123456789.- ') */
padding: 1.15385em /*:= (str_replace($unit, '', $v['secondary-navigation-margin']) / 2) . $unit */;
```