### PR TITLE
Use the stimulus controllers in Contao `^5.3`

### DIFF
--- a/src/ThemeAssistantDataContainer.php
+++ b/src/ThemeAssistantDataContainer.php
@@ -321,15 +321,15 @@ class ThemeAssistantDataContainer extends DataContainer implements ListableDataC
 				}
 
 				$return .= "\n\n" . '<fieldset' . ($key ? ' id="pal_'.$key.'"' : '') . ' class="' . $class . ($legend ? '' : ' nolegend'). '"'
-						.' data-controller="contao--toggle-fieldset"'
-						.' data-contao--toggle-fieldset-id-value="' . $key . '"'
-						.' data-contao--toggle-fieldset-table-value="' . $this->strTable . '"'
-						.' data-contao--toggle-fieldset-collapsed-class="collapsed"'.
-						' data-contao--jump-targets-target="section"'.
-						' data-contao--jump-targets-label-value="'
-						. ($GLOBALS['TL_LANG'][$this->strTable][$key] ?? $key)
-						. '" data-action="contao--jump-targets:scrollto->contao--toggle-fieldset#open">'
-						. $legend;
+					.' data-controller="contao--toggle-fieldset"'
+					.' data-contao--toggle-fieldset-id-value="' . $key . '"'
+					.' data-contao--toggle-fieldset-table-value="' . $this->strTable . '"'
+					.' data-contao--toggle-fieldset-collapsed-class="collapsed"'.
+					' data-contao--jump-targets-target="section"'.
+					' data-contao--jump-targets-label-value="'
+					. ($GLOBALS['TL_LANG'][$this->strTable][$key] ?? $key)
+					. '" data-action="contao--jump-targets:scrollto->contao--toggle-fieldset#open">'
+					. $legend;
 
 				// Build rows of the current box
 				foreach ($v as $vv) {
@@ -450,7 +450,7 @@ class ThemeAssistantDataContainer extends DataContainer implements ListableDataC
 			         . '</script>';
 		}
 
-        if ($this->hasStimulusControllers) {
+		if ($this->hasStimulusControllers) {
 			$return = '<div data-controller="contao--jump-targets">'
 					. '<div class="jump-targets">'
 					. '<div class="inner" data-contao--jump-targets-target="navigation">'

--- a/src/ThemeAssistantDataContainer.php
+++ b/src/ThemeAssistantDataContainer.php
@@ -12,6 +12,7 @@
 namespace MadeYourDay\RockSolidThemeAssistant;
 
 use Contao\BackendUser;
+use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\DataContainer;
 use Contao\EditableDataContainerInterface;
 use Contao\Environment;
@@ -53,6 +54,7 @@ class ThemeAssistantDataContainer extends DataContainer implements ListableDataC
 
 		$this->strTable = $strTable;
 		$this->arrModule = $arrModule;
+		$this->hasStimulusControllers = !version_compare(ContaoCoreBundle::getVersion(), '5.2.99', '<');
 
 		// Call onload_callback (e.g. to check permissions)
 		if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback'] ?? null)) {
@@ -200,7 +202,7 @@ class ThemeAssistantDataContainer extends DataContainer implements ListableDataC
 			$eoCount = -1;
 
 			foreach ($theme['files'] as $file) {
-                $return .= '<tr class="hover-row'.((++$eoCount % 2 == 0) ? ' even' : ' odd').'">';
+				$return .= '<tr class="hover-row'.((++$eoCount % 2 == 0) ? ' even' : ' odd').'">';
 				$return .= '<td class="tl_file_list">'.$GLOBALS['TL_LANG']['rocksolid_theme_assistant']['file_types'][$file['type']].' ('.$file['name'].')</td>';
 				$return .= '<td class="tl_file_list tl_right_nowrap">'.$this->generateButtons($file, $this->strTable).'</td>';
 				$return .= '</tr>';
@@ -302,7 +304,13 @@ class ThemeAssistantDataContainer extends DataContainer implements ListableDataC
 
 				if (isset($legends[$k])) {
 					list($key, $cls) = explode(':', $legends[$k]);
-					$legend = "\n" . '<legend onclick="AjaxRequest.toggleFieldset(this,\'' . $key . '\',\'' . $this->strTable . '\')">' . (isset($GLOBALS['TL_LANG'][$this->strTable][$key]) ? $GLOBALS['TL_LANG'][$this->strTable][$key] : $key) . '</legend>';
+
+					if ($this->hasStimulusControllers) {
+						$legend = "\n" . '<legend><button type="button" data-action="click->contao--toggle-fieldset#toggle">' . (isset($GLOBALS['TL_LANG'][$this->strTable][$key]) ? $GLOBALS['TL_LANG'][$this->strTable][$key] : $key) . '</button></legend>';
+                    }
+					else {
+						$legend = "\n" . '<legend onclick="AjaxRequest.toggleFieldset(this,\'' . $key . '\',\'' . $this->strTable . '\')">' . (isset($GLOBALS['TL_LANG'][$this->strTable][$key]) ? $GLOBALS['TL_LANG'][$this->strTable][$key] : $key) . '</legend>';
+					}
 				}
 
 				if (isset($fs[$this->strTable][$key])) {
@@ -312,7 +320,16 @@ class ThemeAssistantDataContainer extends DataContainer implements ListableDataC
 					$class .= (($cls && $legend) ? ' ' . $cls : '');
 				}
 
-				$return .= "\n\n" . '<fieldset' . ($key ? ' id="pal_'.$key.'"' : '') . ' class="' . $class . ($legend ? '' : ' nolegend') . '">' . $legend;
+				$return .= "\n\n" . '<fieldset' . ($key ? ' id="pal_'.$key.'"' : '') . ' class="' . $class . ($legend ? '' : ' nolegend'). '"'
+						.' data-controller="contao--toggle-fieldset"'
+						.' data-contao--toggle-fieldset-id-value="' . $key . '"'
+						.' data-contao--toggle-fieldset-table-value="' . $this->strTable . '"'
+						.' data-contao--toggle-fieldset-collapsed-class="collapsed"'.
+						' data-contao--jump-targets-target="section"'.
+						' data-contao--jump-targets-label-value="'
+						. ($GLOBALS['TL_LANG'][$this->strTable][$key] ?? $key)
+						. '" data-action="contao--jump-targets:scrollto->contao--toggle-fieldset#open">'
+						. $legend;
 
 				// Build rows of the current box
 				foreach ($v as $vv) {
@@ -431,6 +448,16 @@ class ThemeAssistantDataContainer extends DataContainer implements ListableDataC
 			         . '	Backend.vScrollTo(($(\'' . $this->strTable . '\').getElement(\'label.error\').getPosition().y - 20));'
 			         . '});'
 			         . '</script>';
+		}
+
+        if ($this->hasStimulusControllers) {
+			$return = '<div data-controller="contao--jump-targets">'
+					. '<div class="jump-targets">'
+					. '<div class="inner" data-contao--jump-targets-target="navigation">'
+					. '</div>'
+					. '</div>'
+					. $return
+					. '</div>';
 		}
 
 		return $return;

--- a/src/ThemeAssistantDataContainer.php
+++ b/src/ThemeAssistantDataContainer.php
@@ -200,7 +200,7 @@ class ThemeAssistantDataContainer extends DataContainer implements ListableDataC
 			$eoCount = -1;
 
 			foreach ($theme['files'] as $file) {
-				$return .= '<tr class="'.((++$eoCount % 2 == 0) ? 'even' : 'odd').'" onmouseover="Theme.hoverRow(this,1)" onmouseout="Theme.hoverRow(this,0)">';
+                $return .= '<tr class="hover-row'.((++$eoCount % 2 == 0) ? ' even' : ' odd').'">';
 				$return .= '<td class="tl_file_list">'.$GLOBALS['TL_LANG']['rocksolid_theme_assistant']['file_types'][$file['type']].' ('.$file['name'].')</td>';
 				$return .= '<td class="tl_file_list tl_right_nowrap">'.$this->generateButtons($file, $this->strTable).'</td>';
 				$return .= '</tr>';

--- a/src/ThemeAssistantDataContainer.php
+++ b/src/ThemeAssistantDataContainer.php
@@ -452,12 +452,12 @@ class ThemeAssistantDataContainer extends DataContainer implements ListableDataC
 
 		if ($this->hasStimulusControllers) {
 			$return = '<div data-controller="contao--jump-targets">'
-					. '<div class="jump-targets">'
-					. '<div class="inner" data-contao--jump-targets-target="navigation">'
-					. '</div>'
-					. '</div>'
-					. $return
-					. '</div>';
+				. '<div class="jump-targets">'
+				. '<div class="inner" data-contao--jump-targets-target="navigation">'
+				. '</div>'
+				. '</div>'
+				. $return
+				. '</div>';
 		}
 
 		return $return;

--- a/src/ThemeAssistantDataContainer.php
+++ b/src/ThemeAssistantDataContainer.php
@@ -307,7 +307,7 @@ class ThemeAssistantDataContainer extends DataContainer implements ListableDataC
 
 					if ($this->hasStimulusControllers) {
 						$legend = "\n" . '<legend><button type="button" data-action="click->contao--toggle-fieldset#toggle">' . (isset($GLOBALS['TL_LANG'][$this->strTable][$key]) ? $GLOBALS['TL_LANG'][$this->strTable][$key] : $key) . '</button></legend>';
-                    }
+					}
 					else {
 						$legend = "\n" . '<legend onclick="AjaxRequest.toggleFieldset(this,\'' . $key . '\',\'' . $this->strTable . '\')">' . (isset($GLOBALS['TL_LANG'][$this->strTable][$key]) ? $GLOBALS['TL_LANG'][$this->strTable][$key] : $key) . '</legend>';
 					}

--- a/src/ThemeAssistantDataContainer.php
+++ b/src/ThemeAssistantDataContainer.php
@@ -54,7 +54,7 @@ class ThemeAssistantDataContainer extends DataContainer implements ListableDataC
 
 		$this->strTable = $strTable;
 		$this->arrModule = $arrModule;
-		$this->hasStimulusControllers = !version_compare(ContaoCoreBundle::getVersion(), '5.2.99', '<');
+		$this->hasStimulusControllers = version_compare(ContaoCoreBundle::getVersion(), '5.3', '>=');
 
 		// Call onload_callback (e.g. to check permissions)
 		if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback'] ?? null)) {


### PR DESCRIPTION
### Description

Whilst updating a theme to Contao 5.3+, I noticed the following things

1. `Theme.hoverRow()` being deprecated and throwing errors in the Backend in ^Contao 5
    <img width="365" height="73" alt="image" src="https://github.com/user-attachments/assets/43e2f44e-a710-46ac-8adf-a5995712d160" />
    <img width="549" height="53" alt="image" src="https://github.com/user-attachments/assets/d7b92b63-5def-4f32-8f43-1ec094c1931a" />
    - fixed in ec8b7f1696e4d979197075dfee02af6c82443182

2. There was some really wonky behavior with the legends migrating via the fieldset-legend controller whereas they would become tabbable after opening it. I introduced the stimulus data-attributes for versions `^5.3` to match the fieldset legends
    - see 76cf01d028a700e778f0dd1e69a281f1b5576a67
    <img width="623" height="456" alt="image" src="https://github.com/user-attachments/assets/a3369731-53d8-4794-b1a7-e87bcb8d57b0" />

3. I also added the jump-target-navigation for ^Contao 5.3 because it felt like an easy addition :)
    <img width="1326" height="771" alt="image" src="https://github.com/user-attachments/assets/46251c0e-02a3-4b83-8ccd-2bf29118d432" />
